### PR TITLE
Add operator for retrieving an OData spatial point

### DIFF
--- a/Bonsai.Tinkerforge/Bonsai.Tinkerforge.csproj
+++ b/Bonsai.Tinkerforge/Bonsai.Tinkerforge.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.6.0" />
+    <PackageReference Include="Microsoft.Spatial" Version="7.12.0" />
     <PackageReference Include="Tinkerforge" Version="2.1.30.1" />
   </ItemGroup>
 	

--- a/Bonsai.Tinkerforge/GPSV2GeographyPoint.cs
+++ b/Bonsai.Tinkerforge/GPSV2GeographyPoint.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Microsoft.Spatial;
+
+namespace Bonsai.Tinkerforge
+{
+    /// <summary>
+    /// Represents an operator that retrieves a stream of geography points,
+    /// with or without altitude, from a sequence of GPSV2 coordinates.
+    /// </summary>
+    [Combinator]
+    [Description("Retrieves a stream of geography points, with or without altitude, from a sequence of GPSV2 coordinates.")]
+    [WorkflowElementCategory(ElementCategory.Combinator)]
+    public class GPSV2GeographyPoint
+    {
+        static GeographyPoint CreateGeographyPoint(ref GPSV2CoordinateDataFrame coordinate, double? altitude)
+        {
+            const double ValueToDegrees = 1.0 / 1000000;
+            var latitude = coordinate.Latitude * ValueToDegrees;
+            var longitude = coordinate.Longitude * ValueToDegrees;
+            if (coordinate.NS == 'S') latitude = -latitude;
+            if (coordinate.EW == 'W') longitude = -longitude;
+            return GeographyPoint.Create(latitude, longitude, altitude);
+        }
+
+        /// <summary>
+        /// Retrieves a stream of geography points from a sequence of GPSV2 coordinates.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of <see cref="GPSV2CoordinateDataFrame"/> representing a GPS
+        /// coordinate.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="GeographyPoint"/> objects representing the GPS
+        /// location.
+        /// </returns>
+        public IObservable<GeographyPoint> Process(IObservable<GPSV2CoordinateDataFrame> source)
+        {
+            return source.Select(input => CreateGeographyPoint(ref input, altitude: null));
+        }
+
+        /// <summary>
+        /// Retrieves a stream of geography points with altitude information from a
+        /// sequence of pairs containing GPSV2 coordinates and altitude data.
+        /// </summary>
+        /// <param name="source">
+        /// A sequence of pairs containing a <see cref="GPSV2CoordinateDataFrame"/>
+        /// representing a GPS coordinate, and a <see cref="GPSV2AltitudeDataFrame"/>
+        /// representing altitude data.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="GeographyPoint"/> objects representing the GPS
+        /// location with altitude information.
+        /// </returns>
+        public IObservable<GeographyPoint> Process(IObservable<Tuple<GPSV2CoordinateDataFrame, GPSV2AltitudeDataFrame>> source)
+        {
+            return source.Select(input =>
+            {
+                const double ValueToAltitude = 1.0 / 100;
+                var coordinate = input.Item1;
+                var altitude = input.Item2.Altitude * ValueToAltitude;
+                return CreateGeographyPoint(ref coordinate, altitude);
+            });
+        }
+    }
+}

--- a/Bonsai.Tinkerforge/GPSV2GeographyPoint.cs
+++ b/Bonsai.Tinkerforge/GPSV2GeographyPoint.cs
@@ -12,7 +12,7 @@ namespace Bonsai.Tinkerforge
     /// </summary>
     [Combinator]
     [Description("Retrieves a stream of geography points, with or without altitude, from a sequence of GPSV2 coordinates.")]
-    [WorkflowElementCategory(ElementCategory.Combinator)]
+    [WorkflowElementCategory(ElementCategory.Transform)]
     public class GPSV2GeographyPoint
     {
         static GeographyPoint CreateGeographyPoint(ref GPSV2CoordinateDataFrame coordinate, double? altitude)


### PR DESCRIPTION
This PR adds support for emitting GPS coordinates using the [Microsoft.Spatial](https://docs.microsoft.com/en-us/dotnet/api/microsoft.spatial?view=odata-spatial-7.0) API.

Fixes #7 