### PR TITLE
Prevent Bricklet device source connection errors from crashing the process

### DIFF
--- a/src/Bonsai.Tinkerforge/AirQuality.cs
+++ b/src/Bonsai.Tinkerforge/AirQuality.cs
@@ -67,13 +67,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<AirQualityDataFrame> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletAirQuality(Uid, connection),
+                connection => new BrickletAirQuality(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/AmbientLightV3.cs
+++ b/src/Bonsai.Tinkerforge/AmbientLightV3.cs
@@ -65,13 +65,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<long> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletAmbientLightV3(Uid, connection),
+                connection => new BrickletAmbientLightV3(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/AnalogInV3.cs
+++ b/src/Bonsai.Tinkerforge/AnalogInV3.cs
@@ -52,13 +52,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<int> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletAnalogInV3(Uid, connection),
+                connection => new BrickletAnalogInV3(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/AnalogOutV3.cs
+++ b/src/Bonsai.Tinkerforge/AnalogOutV3.cs
@@ -71,13 +71,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public IObservable<int> Process(IObservable<IPConnection> source, IObservable<int> signal)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletAnalogOutV3(Uid, connection),
+                connection => new BrickletAnalogOutV3(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/AnalogOutV3.cs
+++ b/src/Bonsai.Tinkerforge/AnalogOutV3.cs
@@ -76,33 +76,31 @@ namespace Bonsai.Tinkerforge
                 throw new ArgumentException("A device Uid must be specified", "Uid");
             }
 
-            return source.SelectStream(connection =>
-            {
-                var device = new BrickletAnalogOutV3(Uid, connection);
-                connection.Connected += (sender, e) =>
+            return source.SelectStream(
+                connection => new BrickletAnalogOutV3(Uid, connection),
+                device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);
-                };
 
-                return Observable.Create<BrickletAnalogOutV3>(observer =>
-                {
-                    observer.OnNext(device);
-                    return Disposable.Create(() =>
+                    return Observable.Create<BrickletAnalogOutV3>(observer =>
                     {
-                        try { device.SetStatusLEDConfig(0); }
-                        catch (NotConnectedException) { }
+                        observer.OnNext(device);
+                        return Disposable.Create(() =>
+                        {
+                            try { device.SetStatusLEDConfig(0); }
+                            catch (NotConnectedException) { }
+                        });
                     });
-                });
-            }).SelectMany(device =>
-            {
-                var voltage = signal;
-                var initialVoltage = InitialVoltage;
-                if (initialVoltage.HasValue)
+                }).SelectMany(device =>
                 {
-                    voltage = Observable.Return(initialVoltage.Value).Concat(signal);
-                }
-                return voltage.Do(device.SetOutputVoltage);
-            });
+                    var voltage = signal;
+                    var initialVoltage = InitialVoltage;
+                    if (initialVoltage.HasValue)
+                    {
+                        voltage = Observable.Return(initialVoltage.Value).Concat(signal);
+                    }
+                    return voltage.Do(device.SetOutputVoltage);
+                });
         }
     }
 

--- a/src/Bonsai.Tinkerforge/CO2V2.cs
+++ b/src/Bonsai.Tinkerforge/CO2V2.cs
@@ -65,13 +65,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<CO2V2DataFrame> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletCO2V2(Uid, connection),
+                connection => new BrickletCO2V2(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/GPSV2.cs
+++ b/src/Bonsai.Tinkerforge/GPSV2.cs
@@ -82,13 +82,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<BrickletGPSV2> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletGPSV2(Uid, connection),
+                connection => new BrickletGPSV2(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/GPSV2.cs
+++ b/src/Bonsai.Tinkerforge/GPSV2.cs
@@ -87,10 +87,9 @@ namespace Bonsai.Tinkerforge
                 throw new ArgumentException("A device Uid must be specified", "Uid");
             }
 
-            return source.SelectStream(connection =>
-            {
-                var device = new BrickletGPSV2(Uid, connection);
-                connection.Connected += (sender, e) =>
+            return source.SelectStream(
+                connection => new BrickletGPSV2(Uid, connection),
+                device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);
                     device.SetSBASConfig((byte)SBAS);
@@ -98,18 +97,17 @@ namespace Bonsai.Tinkerforge
                     device.SetAltitudeCallbackPeriod(AltitudePeriod);
                     device.SetCoordinatesCallbackPeriod(CoordinatePeriod);
                     device.SetStatusCallbackPeriod(StatusPeriod);
-                };
 
-                return Observable.Create<BrickletGPSV2>(observer =>
-                {
-                    observer.OnNext(device);
-                    return Disposable.Create(() =>
+                    return Observable.Create<BrickletGPSV2>(observer =>
                     {
-                        try { device.SetStatusLEDConfig(0); }
-                        catch (NotConnectedException) { }
+                        observer.OnNext(device);
+                        return Disposable.Create(() =>
+                        {
+                            try { device.SetStatusLEDConfig(0); }
+                            catch (NotConnectedException) { }
+                        });
                     });
                 });
-            });
         }
     }
 

--- a/src/Bonsai.Tinkerforge/HumidityV2.cs
+++ b/src/Bonsai.Tinkerforge/HumidityV2.cs
@@ -75,13 +75,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<int> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletHumidityV2(Uid, connection),
+                connection => new BrickletHumidityV2(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/IndustrialAnalogOutV2.cs
+++ b/src/Bonsai.Tinkerforge/IndustrialAnalogOutV2.cs
@@ -106,13 +106,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public IObservable<int> Process(IObservable<IPConnection> source, IObservable<int> signal)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletAnalogOutV3(Uid, connection),
+                connection => new BrickletAnalogOutV3(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/IndustrialDual020mAV2.cs
+++ b/src/Bonsai.Tinkerforge/IndustrialDual020mAV2.cs
@@ -60,13 +60,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<int> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletIndustrialDual020mAV2(Uid, connection),
+                connection => new BrickletIndustrialDual020mAV2(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/IndustrialPTC.cs
+++ b/src/Bonsai.Tinkerforge/IndustrialPTC.cs
@@ -75,13 +75,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<int> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletIndustrialPTC(Uid, connection),
+                connection => new BrickletIndustrialPTC(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/PTC.cs
+++ b/src/Bonsai.Tinkerforge/PTC.cs
@@ -74,13 +74,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<int> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletPTC(Uid, connection),
+                connection => new BrickletPTC(uid, connection),
                 device =>
                 {
                     device.SetWireMode((byte)WireMode);

--- a/src/Bonsai.Tinkerforge/PTCV2.cs
+++ b/src/Bonsai.Tinkerforge/PTCV2.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using Tinkerforge;
 
@@ -80,33 +79,28 @@ namespace Bonsai.Tinkerforge
                 throw new ArgumentException("A device Uid must be specified", "Uid");
             }
 
-            return source.SelectStream(connection =>
-            {
-                var device = new BrickletPTCV2(Uid, connection);
-                connection.Connected += (sender, e) =>
+            return source.SelectStream(
+                connection => new BrickletPTCV2(Uid, connection),
+                device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);
                     device.SetWireMode((byte)WireMode);
                     device.SetMovingAverageConfiguration(MovingAverageLengthResistance, MovingAverageLengthTemperature);
                     device.SetTemperatureCallbackConfiguration(Period, false, 'x', 0, 0);
-                };
 
-                return Observable.Create<int>(observer =>
-                {
-                    BrickletPTCV2.TemperatureEventHandler handler = (sender, temperature) =>
-                    {
-                        observer.OnNext(temperature);
-                    };
-
-                    device.TemperatureCallback += handler;
-                    return Disposable.Create(() =>
-                    {
-                        try { device.SetTemperatureCallbackConfiguration(0, false, 'x', 0, 0); }
-                        catch (NotConnectedException) { }
-                        device.TemperatureCallback -= handler;
-                    });
+                    return Observable.FromEvent<BrickletPTCV2.TemperatureEventHandler, int>(
+                        onNext => (sender, temperature) =>
+                        {
+                            onNext(temperature);
+                        },
+                        handler => device.TemperatureCallback += handler,
+                        handler => device.TemperatureCallback -= handler)
+                        .Finally(() =>
+                        {
+                            try { device.SetTemperatureCallbackConfiguration(0, false, 'x', 0, 0); }
+                            catch (NotConnectedException) { }
+                        });
                 });
-            });
         }
 
         /// <summary>

--- a/src/Bonsai.Tinkerforge/PTCV2.cs
+++ b/src/Bonsai.Tinkerforge/PTCV2.cs
@@ -74,13 +74,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<int> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletPTCV2(Uid, connection),
+                connection => new BrickletPTCV2(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/ParticulateMatter.cs
+++ b/src/Bonsai.Tinkerforge/ParticulateMatter.cs
@@ -53,13 +53,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<ParticulateMatterDataFrame> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletParticulateMatter(Uid, connection),
+                connection => new BrickletParticulateMatter(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/SoundPressureLevel.cs
+++ b/src/Bonsai.Tinkerforge/SoundPressureLevel.cs
@@ -66,13 +66,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public override IObservable<int> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletSoundPressureLevel(Uid, connection),
+                connection => new BrickletSoundPressureLevel(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/ThermocoupleV2.cs
+++ b/src/Bonsai.Tinkerforge/ThermocoupleV2.cs
@@ -75,13 +75,10 @@ namespace Bonsai.Tinkerforge
         /// </returns>
         public IObservable<int> Process(IObservable<IPConnection> source)
         {
-            if (string.IsNullOrEmpty(Uid))
-            {
-                throw new ArgumentException("A device Uid must be specified", "Uid");
-            }
+            var uid = UidHelper.ThrowIfNullOrEmpty(Uid);
 
             return source.SelectStream(
-                connection => new BrickletThermocoupleV2(Uid, connection),
+                connection => new BrickletThermocoupleV2(uid, connection),
                 device =>
                 {
                     device.SetStatusLEDConfig((byte)StatusLed);

--- a/src/Bonsai.Tinkerforge/UidHelper.cs
+++ b/src/Bonsai.Tinkerforge/UidHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Bonsai.Tinkerforge
+{
+    internal static class UidHelper
+    {
+        public static string ThrowIfNullOrEmpty(string uid)
+        {
+            if (string.IsNullOrEmpty(uid))
+            {
+                throw new InvalidOperationException("A bricklet device UID must be specified.");
+            }
+
+            return uid;
+        }
+    }
+}


### PR DESCRIPTION
This PR prevents errors raised in Tinkerforge asynchronous callbacks from crashing the process when no device with the specified UID is present in the network.

Specifically, the Bricklet device source initialization logic was reorganized to route connection timeout errors into the observable sequence itself. All refactoring was also abstracted into a common operator to make it easier to modify this logic in the future.

Common UID error checking was also refactored into a common method. It is not possible at the moment to refactor the property declaration itself, since it requires a typed attribute that is individual to each device type (for filtering purposes). At the moment attributes do not support using generic types so the explicit declaration has to be preserved.

Fixes #14 
Fixes #17 