### PR TITLE
Add Brick daemon installation steps

### DIFF
--- a/docs/articles/intro.md
+++ b/docs/articles/intro.md
@@ -1,4 +1,8 @@
 Getting Started
 ===============
 
-The easiest way to start using Bonsai.Tinkerforge in your projects is to install the NuGet package from the Bonsai package manager.
+1. Download [Bonsai](https://bonsai-rx.org/).
+2. From the package manager, search and install the **Bonsai - Tinkerforge** package.
+
+> [!Warning]
+> The Tinkerforge package requires the [Brick Daemon](https://www.tinkerforge.com/en/doc/Software/Brickd.html) service to be running in the background on the host computer to which the Bricks/Bricklets are connected. Please see the Tinkerforge documentation page for [installation](https://www.tinkerforge.com/en/doc/Software/Brickd.html#installation) instructions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # **Bonsai - Tinkerforge** Documentation
 
-Bonsai library containing interfaces for data acquisition and control using Tinkerforge devices.
+Bonsai.Tinkerforge is a [Bonsai](https://bonsai-rx.org/) interface for [Tinkerforge](https://www.tinkerforge.com/) hardware allowing data acquisition and control of Bricks and Bricklet devices.
 
 > [!Warning]
 > These docs are under active development, feel free to contribute by either [raising an issue](https://github.com/emotional-cities/tinkerforge/issues) or following the links to **Improve this Doc**.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,4 +1,4 @@
-- name: Articles
+- name: Manual
   href: articles/
-- name: API Documentation
+- name: Reference
   href: api/


### PR DESCRIPTION
This PR improves the documentation by adding a link to the installation instructions for the Brick daemon service which is required to run in the background for device discovery and connection to Bricks and Bricklets to work properly.

Fixes #16 