### PR TITLE
Trigger documentation build when tagging a release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,9 @@ name: Build docs
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds a GitHub actions trigger for automatically building documentation pages when tagging a new release.

Fixes #4 